### PR TITLE
fix incorrect reference for comment id in report

### DIFF
--- a/.github/workflows/build-target.yaml
+++ b/.github/workflows/build-target.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Report test warning on build only
         if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && inputs.build_only == 'true' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Testing skipped' -iid '${{ inputs.issue_num }}#issue-${{ inputs.test_comment_id }}' -state 'warning' -context 'test' -token 'PLACEHOLDER' -repo ewlu/gcc-precommit-ci
+          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Testing skipped' -iid '${{ inputs.issue_num }}#issue-${{ steps.test-comment.outputs.comment-id }}' -state 'warning' -context 'test' -token 'PLACEHOLDER' -repo ewlu/gcc-precommit-ci
         continue-on-error: true
 
     outputs:


### PR DESCRIPTION
fixes missing comment id when passing in argument -iid. (looks like `<num>#issue-` instead of `<num>#issue-<cid>`) https://github.com/ewlu/gcc-precommit-ci/actions/runs/6580935069/job/17880493262#step:7:73