### PR TITLE
escape tag <patch_name> when generating markdown

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -89,7 +89,7 @@ jobs:
           echo "## Lint Status" > comment.md
           cat linter_fail_report.md >> comment.md
           head -c 65000 comment.md > trimmed_comment.md
-          if [ $(cat trimmed_comment.md | wc -l) -ne $(cat comment.md | wc -l) ]; then printf "\n\`\`\`\nComment text has been trimmed. Please check logs for the untrimmed comment.\nLogs -> <patch name> -> lint -> Lint patch step" >> trimmed_comment.md; fi
+          if [ $(cat trimmed_comment.md | wc -l) -ne $(cat comment.md | wc -l) ]; then printf "\n\`\`\`\nComment text has been trimmed. Please check logs for the untrimmed comment.\nLogs -> \<patch name\> -> lint -> Lint patch step" >> trimmed_comment.md; fi
           printf "\n[Additional information](${{ inputs.additional_info }})\n" >> trimmed_comment.md
 
       - name: Update lint failed comment report


### PR DESCRIPTION
https://github.com/ewlu/gcc-precommit-ci/issues/396#issuecomment-1773124055 does not display the correct markdown for how to find logs