### PR TITLE
Pass event to post_check_to_patchworks.py

### DIFF
--- a/.github/workflows/build-target.yaml
+++ b/.github/workflows/build-target.yaml
@@ -88,9 +88,9 @@ jobs:
           edit-mode: replace
 
       - name: Report test warning on build only
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && inputs.build_only == 'true' }}
+        if: ${{ inputs.build_only == 'true' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Testing skipped' -iid '${{ inputs.issue_num }}#issue-${{ steps.test-comment.outputs.comment-id }}' -state 'warning' -context 'test' -token 'PLACEHOLDER' -repo ewlu/gcc-precommit-ci
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Testing skipped' -iid '${{ inputs.issue_num }}#issue-${{ steps.test-comment.outputs.comment-id }}' -state 'warning' -context 'test' -token 'PLACEHOLDER' -repo ewlu/gcc-precommit-ci
         continue-on-error: true
 
     outputs:

--- a/.github/workflows/call-patchworks-api.yaml
+++ b/.github/workflows/call-patchworks-api.yaml
@@ -100,7 +100,7 @@ jobs:
       - name: Report pass
         run: |
           if [ ${{ needs.get-patch-info.outputs.check }} == 'Apply' ]; then export DESC="Patch applied"; else export DESC="${{ needs.get-patch-info.outputs.check }} passed"; fi
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid ${{ needs.get-patch-info.outputs.patch_id }} -desc "$DESC" -iid ${{ github.event.issue.number }} -state 'success' -context '${{ needs.get-patch-info.outputs.context }}' -token ${{ secrets.PATCHWORK_API }} -comment
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid ${{ needs.get-patch-info.outputs.patch_id }} -desc "$DESC" -iid ${{ github.event.issue.number }} -state 'success' -context '${{ needs.get-patch-info.outputs.context }}' -token ${{ secrets.PATCHWORK_API }} -comment
 
 
   report-warn:
@@ -129,7 +129,7 @@ jobs:
 
       - name: Report Warning
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid ${{ needs.get-patch-info.outputs.patch_id }} -desc '${{ needs.get-patch-info.outputs.check }} warning' -iid ${{ github.event.issue.number }} -state 'warning' -context '${{ needs.get-patch-info.outputs.context }}' -token ${{ secrets.PATCHWORK_API }} -comment
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid ${{ needs.get-patch-info.outputs.patch_id }} -desc '${{ needs.get-patch-info.outputs.check }} warning' -iid ${{ github.event.issue.number }} -state 'warning' -context '${{ needs.get-patch-info.outputs.context }}' -token ${{ secrets.PATCHWORK_API }} -comment
 
 
   report-error:
@@ -159,4 +159,4 @@ jobs:
       - name: Report Error
         run: |
           if [ ${{ needs.get-patch-info.outputs.check }} == 'Apply' ]; then export DESC="Patch failed to apply"; else export DESC="${{ needs.get-patch-info.outputs.check }} failed"; fi
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid ${{ needs.get-patch-info.outputs.patch_id }} -desc "$DESC" -iid ${{ github.event.issue.number }} -state 'fail' -context '${{ needs.get-patch-info.outputs.context }}' -token ${{ secrets.PATCHWORK_API }} -comment
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid ${{ needs.get-patch-info.outputs.patch_id }} -desc "$DESC" -iid ${{ github.event.issue.number }} -state 'fail' -context '${{ needs.get-patch-info.outputs.context }}' -token ${{ secrets.PATCHWORK_API }} -comment

--- a/.github/workflows/generate-precommit-summary.yaml
+++ b/.github/workflows/generate-precommit-summary.yaml
@@ -338,15 +338,15 @@ jobs:
             })
 
       - name: Report Failure
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && contains(steps.issue-labels.outputs.issue_labels, 'build-failure') || contains(steps.issue-labels.outputs.issue_labels, 'testsuite-failure') || contains(steps.issue-labels.outputs.issue_labels, 'new-regressions') }}
+        if: ${{ contains(steps.issue-labels.outputs.issue_labels, 'build-failure') || contains(steps.issue-labels.outputs.issue_labels, 'testsuite-failure') || contains(steps.issue-labels.outputs.issue_labels, 'new-regressions') }}
         id: report-failure
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 ./patches/${{ inputs.patch_name }} -desc 'Testing failed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.test_comment_id }}' -state 'fail' -context 'test' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 ./patches/${{ inputs.patch_name }} -desc 'Testing failed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.test_comment_id }}' -state 'fail' -context 'test' -token 'PLACEHOLDER'
         continue-on-error: true
 
       - name: Report Success
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.report-failure.outcome == 'skipped' }}
+        if: ${{ steps.report-failure.outcome == 'skipped' }}
         id: report-success
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 ./patches/${{ inputs.patch_name }} -desc 'Testing passed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.test_comment_id }}' -state 'success' -context 'test' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 ./patches/${{ inputs.patch_name }} -desc 'Testing passed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.test_comment_id }}' -state 'success' -context 'test' -token 'PLACEHOLDER'
         continue-on-error: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Report start linter
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Linter starting' -iid '${{ inputs.issue_num }}#issue-${{ inputs.lint_comment_id }}' -state 'pending' -context 'linter' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Linter starting' -iid '${{ inputs.issue_num }}#issue-${{ inputs.lint_comment_id }}' -state 'pending' -context 'linter' -token 'PLACEHOLDER'
 
       # Only lint the last patch in the series since that's where the warning will be displayed
       - name: Lint patch
@@ -116,9 +116,9 @@ jobs:
             })
 
       - name: Report linter warning
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.lint.outputs.lint_failed == 'true' }}
+        if: ${{ steps.lint.outputs.lint_failed == 'true' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Lint failed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.lint_comment_id }}' -state 'warning' -context 'linter' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Lint failed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.lint_comment_id }}' -state 'warning' -context 'linter' -token 'PLACEHOLDER'
 
       - name: Make lint passed comment
         if: ${{ steps.lint.outputs.lint_failed == 'false' }}
@@ -138,7 +138,7 @@ jobs:
           edit-mode: replace
 
       - name: Report linter success
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.lint.outputs.lint_failed == 'false' }}
+        if: ${{ steps.lint.outputs.lint_failed == 'false' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Lint passed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.lint_comment_id }}' -state 'success' -context 'linter' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Lint passed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.lint_comment_id }}' -state 'success' -context 'linter' -token 'PLACEHOLDER'
 

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -304,15 +304,15 @@ jobs:
           edit-mode: replace
 
       - name: Report patch failed to apply to tip of tree
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.apply-baseline.outputs.apply_baseline == 'true' && steps.apply-tip-of-tree.outputs.apply_tot == 'false' }}
+        if: ${{ steps.apply-baseline.outputs.apply_baseline == 'true' && steps.apply-tip-of-tree.outputs.apply_tot == 'false' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }}) -desc 'Patch did not apply to tip of tree.' -iid '${{ needs.create-issue.outputs.issue_number }}#issue-${{ needs.create-issue.outputs.apply_comment_id }}' -state 'warning' -context 'apply-patch' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }}) -desc 'Patch did not apply to tip of tree.' -iid '${{ needs.create-issue.outputs.issue_number }}#issue-${{ needs.create-issue.outputs.apply_comment_id }}' -state 'warning' -context 'apply-patch' -token 'PLACEHOLDER'
         continue-on-error: true
 
       - name: Report patch applied to tip of tree successfully
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.apply-tip-of-tree.outputs.apply_tot == 'true' }}
+        if: ${{ steps.apply-tip-of-tree.outputs.apply_tot == 'true' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }}) -desc 'Patch applied to tip of tree successfully.' -iid '${{ needs.create-issue.outputs.issue_num }}#issue-${{ needs.create-issue.outputs.apply_comment_id }}' -state 'success' -context 'apply-patch' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }}) -desc 'Patch applied to tip of tree successfully.' -iid '${{ needs.create-issue.outputs.issue_num }}#issue-${{ needs.create-issue.outputs.apply_comment_id }}' -state 'success' -context 'apply-patch' -token 'PLACEHOLDER'
         continue-on-error: true
 
       - name: Output the hash after the patch has been applied

--- a/.github/workflows/test-regression.yaml
+++ b/.github/workflows/test-regression.yaml
@@ -136,9 +136,8 @@ jobs:
           edit-mode: replace
 
       - name: Report build
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Build started' -iid '${{ inputs.issue_num }}#issue-${{ inputs.build_comment_id }}' -state 'pending' -context 'build--${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.multilib }}' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Build started' -iid '${{ inputs.issue_num }}#issue-${{ inputs.build_comment_id }}' -state 'pending' -context 'build--${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.multilib }}' -token 'PLACEHOLDER'
         continue-on-error: true
 
       - name: Configure
@@ -219,9 +218,9 @@ jobs:
           edit-mode: replace
 
       - name: Report error on build-failure
-        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.build-gcc.outcome == 'failure' }}
+        if: ${{ always() && steps.build-gcc.outcome == 'failure' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Build failed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.build_comment_id }}' -state 'fail' -context 'build--${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.multilib }}' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Build failed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.build_comment_id }}' -state 'fail' -context 'build--${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.multilib }}' -token 'PLACEHOLDER'
         continue-on-error: true
 
       - name: Remove sources to reclaim disk space
@@ -261,9 +260,8 @@ jobs:
           echo "build_success=$BUILD_SUCCESS" >> "$GITHUB_OUTPUT"
 
       - name: Report build success
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Build passed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.build_comment_id }}' -state 'success' -context 'build--${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.multilib }}' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Build passed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.build_comment_id }}' -state 'success' -context 'build--${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.multilib }}' -token 'PLACEHOLDER'
         continue-on-error: true
 
     outputs:
@@ -415,9 +413,8 @@ jobs:
           edit-mode: replace
 
       - name: Report testing
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Testing started' -iid '${{ inputs.issue_num }}#issue-${{ inputs.test_comment_id }}' -state 'pending' -context 'test' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Testing started' -iid '${{ inputs.issue_num }}#issue-${{ inputs.test_comment_id }}' -state 'pending' -context 'test' -token 'PLACEHOLDER'
         continue-on-error: true
 
       - name: Reinstall stage2
@@ -761,9 +758,8 @@ jobs:
           edit-mode: replace
 
       - name: Report build
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Build started' -iid '${{ inputs.issue_num }}#issue-${{ inputs.build_comment_id }}' -state 'pending' -context 'build--${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.multilib }}' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Build started' -iid '${{ inputs.issue_num }}#issue-${{ inputs.build_comment_id }}' -state 'pending' -context 'build--${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.multilib }}' -token 'PLACEHOLDER'
         continue-on-error: true
 
       - name: Configure
@@ -844,15 +840,14 @@ jobs:
           edit-mode: replace
 
       - name: Report error on build-failure
-        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.build-gcc.outcome == 'failure' }}
+        if: ${{ always() && steps.build-gcc.outcome == 'failure' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Build failed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.build_comment_id }}' -state 'fail' -context 'build--${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.multilib }}' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Build failed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.build_comment_id }}' -state 'fail' -context 'build--${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.multilib }}' -token 'PLACEHOLDER'
         continue-on-error: true
 
       - name: Report build success
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Build passed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.build_comment_id }}' -state 'success' -context 'build--${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.multilib }}' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Build passed' -iid '${{ inputs.issue_num }}#issue-${{ inputs.build_comment_id }}' -state 'success' -context 'build--${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.multilib }}' -token 'PLACEHOLDER'
         continue-on-error: true
 
       - name: Zip binaries
@@ -901,9 +896,9 @@ jobs:
           edit-mode: replace
 
       - name: Report testing
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && inputs.build_only != 'true' }}
+        if: ${{ inputs.build_only != 'true' }}
         run: |
-          python scripts/post_check_to_patchworks.py -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Testing started' -iid '${{ inputs.issue_num }}#issue-${{ inputs.test_comment_id }}' -state 'pending' -context 'test' -token 'PLACEHOLDER'
+          python scripts/post_check_to_patchworks.py -event ${{ github.event_name }} -repo ewlu/gcc-precommit-ci -pid $(tail -n 1 patches/${{ inputs.patch_name }})  -desc 'Testing started' -iid '${{ inputs.issue_num }}#issue-${{ inputs.test_comment_id }}' -state 'pending' -context 'test' -token 'PLACEHOLDER'
         continue-on-error: true
 
       - name: Run testsuite


### PR DESCRIPTION
Depends on https://github.com/patrick-rivos/riscv-gnu-toolchain/pull/442. Allows us to error out on nasty bugs like this one where we forget the `if`:
https://github.com/ewlu/gcc-precommit-ci/blob/fc7001f0f2ecfed69990473d1ff2e0585531622c/.github/workflows/lint.yaml#L64