### PR TITLE
Ignore empty commits when applying

### DIFF
--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -233,7 +233,7 @@ jobs:
           cd gcc
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
-          git am ../patches/*.patch --whitespace=fix -q --3way &> out_base || true
+          git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop &> out_base || true
           cat out_base
           if [[ $(cat out_base | wc -l) != 0 ]]; then
             git am --show-current-patch=diff
@@ -253,7 +253,7 @@ jobs:
         run: |
           cd gcc
           git reset --hard ${{ inputs.tot_hash }}
-          git am ../patches/*.patch --whitespace=fix -q --3way &> out_tot || true
+          git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop &> out_tot || true
           cat out_tot
           if [[ $(cat out_tot | wc -l) != 0 ]]; then
             git am --show-current-patch=diff
@@ -346,7 +346,7 @@ jobs:
           if [ "${{ steps.apply-baseline.outputs.apply_baseline }}" == "true" ]; then
             git checkout ${{ inputs.baseline_hash }}
           fi
-          git am ../patches/*.patch --whitespace=fix --3way
+          git am ../patches/*.patch --whitespace=fix --3way --empty=drop
           export PATCH_APPLIED_GCCHASH=$(git rev-parse HEAD)
           echo $PATCH_APPLIED_GCCHASH
           echo "patch_applied_gcchash=$PATCH_APPLIED_GCCHASH" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-regression.yaml
+++ b/.github/workflows/test-regression.yaml
@@ -98,7 +98,7 @@ jobs:
           cd gcc
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
-          git am ../patches/*.patch --whitespace=fix --3way
+          git am ../patches/*.patch --whitespace=fix --3way --empty=drop
           echo $(git rev-parse HEAD)
 
       - name: Install dependencies
@@ -329,7 +329,7 @@ jobs:
           cd gcc
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
-          git am ../patches/*.patch --whitespace=fix --3way
+          git am ../patches/*.patch --whitespace=fix --3way --empty=drop
           echo $(git rev-parse HEAD)
 
       - name: Install dependencies
@@ -567,7 +567,7 @@ jobs:
           cd gcc
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
-          git am ../patches/*.patch --whitespace=fix --3way
+          git am ../patches/*.patch --whitespace=fix --3way --empty=drop
           echo $(git rev-parse HEAD)
 
       - name: Install dependencies
@@ -729,7 +729,7 @@ jobs:
           cd gcc
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
-          git am ../patches/*.patch --whitespace=fix --3way
+          git am ../patches/*.patch --whitespace=fix --3way --empty=drop
           echo $(git rev-parse HEAD)
 
       - name: Install dependencies


### PR DESCRIPTION
Resolves #477 where is misinterprets the first part of the email as a separate patch.
https://github.com/ewlu/gcc-precommit-ci/actions/runs/6658976049/job/18097747516#step:9:30