### PR TITLE
Output diff for fails-to-apply

### DIFF
--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -246,10 +246,13 @@ jobs:
           git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop &> out_base || true
           cat out_base
           if [[ $(cat out_base | wc -l) != 0 ]]; then
-            git am --show-current-patch=diff
+            git am --abort
+            git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop --reject
             echo "Failed to apply patch cleanly to baseline hash"
             echo "\`\`\`" >> out_base
-            git am --show-current-patch=diff &>> out_base
+            git am --abort
+            rm out_base
+            git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop --reject &> out_base
             echo "\`\`\`" >> out_base
             git am --abort
             echo "apply_baseline=false" >> $GITHUB_OUTPUT
@@ -266,9 +269,12 @@ jobs:
           git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop &> out_tot || true
           cat out_tot
           if [[ $(cat out_tot | wc -l) != 0 ]]; then
-            git am --show-current-patch=diff
+            git am --abort
+            git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop --reject
             echo "Failed to apply patch cleanly to tip of tree"
-            git am --show-current-patch=diff &>> out_tot
+            git am --abort
+            rm out_tot
+            git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop --reject &> out_tot
             git am --abort
             echo "apply_tot=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -246,10 +246,10 @@ jobs:
           git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop &> out_base || true
           cat out_base
           if [[ $(cat out_base | wc -l) != 0 ]]; then
-            git am --reject
+            git am --reject || true
             echo "Failed to apply patch cleanly to baseline hash"
             rm out_base
-            git am --reject &> out_base
+            git am --reject &> out_base || true
             git am --abort
             echo "apply_baseline=false" >> $GITHUB_OUTPUT
           else
@@ -265,10 +265,10 @@ jobs:
           git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop &> out_tot || true
           cat out_tot
           if [[ $(cat out_tot | wc -l) != 0 ]]; then
-            git am --reject
+            git am --reject || true
             echo "Failed to apply patch cleanly to tip of tree"
             rm out_tot
-            git am --reject &> out_tot
+            git am --reject &> out_tot || true
             git am --abort
             echo "apply_tot=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -246,13 +246,11 @@ jobs:
           git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop &> out_base || true
           cat out_base
           if [[ $(cat out_base | wc -l) != 0 ]]; then
-            git am --abort
-            git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop --reject
+            git am --reject
             echo "Failed to apply patch cleanly to baseline hash"
             echo "\`\`\`" >> out_base
-            git am --abort
             rm out_base
-            git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop --reject &> out_base
+            git am --reject &> out_base
             echo "\`\`\`" >> out_base
             git am --abort
             echo "apply_baseline=false" >> $GITHUB_OUTPUT
@@ -269,12 +267,10 @@ jobs:
           git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop &> out_tot || true
           cat out_tot
           if [[ $(cat out_tot | wc -l) != 0 ]]; then
-            git am --abort
-            git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop --reject
+            git am --reject
             echo "Failed to apply patch cleanly to tip of tree"
-            git am --abort
             rm out_tot
-            git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop --reject &> out_tot
+            git am --reject &> out_tot
             git am --abort
             echo "apply_tot=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -246,10 +246,12 @@ jobs:
           git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop &> out_base || true
           cat out_base
           if [[ $(cat out_base | wc -l) != 0 ]]; then
-            git am --reject || true
+            git am --abort
+            git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop --reject || true
             echo "Failed to apply patch cleanly to baseline hash"
             rm out_base
-            git am --reject &> out_base || true
+            git am --abort
+            git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop --reject &> out_base || true
             git am --abort
             echo "apply_baseline=false" >> $GITHUB_OUTPUT
           else
@@ -265,10 +267,12 @@ jobs:
           git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop &> out_tot || true
           cat out_tot
           if [[ $(cat out_tot | wc -l) != 0 ]]; then
-            git am --reject || true
+            git am --abort
+            git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop --reject || true
             echo "Failed to apply patch cleanly to tip of tree"
             rm out_tot
-            git am --reject &> out_tot || true
+            git am --abort
+            git am ../patches/*.patch --whitespace=fix -q --3way --empty=drop --reject &> out_tot || true
             git am --abort
             echo "apply_tot=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -248,10 +248,8 @@ jobs:
           if [[ $(cat out_base | wc -l) != 0 ]]; then
             git am --reject
             echo "Failed to apply patch cleanly to baseline hash"
-            echo "\`\`\`" >> out_base
             rm out_base
             git am --reject &> out_base
-            echo "\`\`\`" >> out_base
             git am --abort
             echo "apply_baseline=false" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
This produced outputs like this:
```
diff --cc gcc/testsuite/lib/target-supports.exp
index 81330c4ba55,af0bf0c48d7..00000000000
--- a/gcc/testsuite/lib/target-supports.exp
+++ b/gcc/testsuite/lib/target-supports.exp
@@@ -2111,16 -2063,16 +2122,29 @@@ proc add_options_for_riscv_zfh { flags 
      return "$flags -march=[riscv_get_arch]_zfh"
  }
  
++<<<<<<< HEAD
 +proc add_options_for_riscv_zvfh { flags } {
 +    if { [lsearch $flags -march=*] >= 0 } {
 +	# If there are multiple -march flags, we have to adjust all of them.
 +	set flags [regsub -all -- {(?:^|[[:space:]])-march=[[:alnum:]_.]*} $flags &_zvfh ]
 +	return [regsub -all -- {((?:^|[[:space:]])-march=[[:alnum:]_.]*_zvfh[[:alnum:]_.]*)_zvfh} $flags \\1 ]
 +    }
 +    if { [check_effective_target_riscv_zvfh] } {
 +	return "$flags"
 +    }
 +    return "$flags -march=[riscv_get_arch]_zvfh"
++=======
+ proc add_options_for_riscv_ztso { flags } {
+     if { [lsearch $flags -march=*] >= 0 } {
+ 	# If there are multiple -march flags, we have to adjust all of them.
+ 	set flags [regsub -all -- {(?:^|[[:space:]])-march=[[:alnum:]_.]*} $flags &_ztso ]
+ 	return [regsub -all -- {((?:^|[[:space:]])-march=[[:alnum:]_.]*_ztso[[:alnum:]_.]*)_ztso} $flags \\1 ]
+     }
+     if { [check_effective_target_riscv_ztso] } {
+ 	return "$flags"
+     }
+     return "$flags -march=[riscv_get_arch]_ztso"
++>>>>>>> RISC-V: Enable ztso tests on rv32
  }
  
  # Return 1 if the target OS supports running SSE executables, 0
```
Much more helpful when debugging why a patch doesn't apply IMO.