### PR TITLE
Tee stdout to build log

### DIFF
--- a/.github/actions/common/build-target/action.yaml
+++ b/.github/actions/common/build-target/action.yaml
@@ -59,7 +59,7 @@ runs:
         run: |
           cd build
           set -o pipefail
-          (make -j $(nproc) ${{ inputs.mode }}) 2> >(tee ${{ inputs.build_log_name }}-stderr.log) > ${{ inputs.build_log_name }}-stdout.log | tee ${{ inputs.build_log_name }}.log
+          (make -j $(nproc) ${{ inputs.mode }}) 2> >(tee ${{ inputs.build_log_name }}-stderr.log) > >(tee ${{ inputs.build_log_name }}-stdout.log) | tee ${{ inputs.build_log_name }}.log
           set +o pipefail
 
       - name: Zip build log


### PR DESCRIPTION
Turns out the github runners don't have the same shell as me ;)
The build log with all output only contains stderr. This PR should fix that.