### PR TITLE
rename uc log name to match expected when comparing

### DIFF
--- a/.github/workflows/generate-precommit-summary.yaml
+++ b/.github/workflows/generate-precommit-summary.yaml
@@ -188,6 +188,7 @@ jobs:
       - name: Separate multilib logs
         run: |
           python scripts/separate_multilib_results.py -indir current_logs -outdir current_logs
+          mv current_logs/gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.patch_applied_gcchash }}-non-multilib-report.log current_logs/gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.patch_applied_gcchash }}-multilib-report.log
         continue-on-error: true
 
       - name: Compare artifacts


### PR DESCRIPTION
https://github.com/ewlu/gcc-precommit-ci/actions/runs/9163548707/job/25203037849#step:19:52

By default, `separate_multilib_results.py` will generate multiple files postfixed with `-multilib-report.log` if the originating file was a multilib. Since we build `imc_zba_zbb_zbc_zbs` as a singlelib in precommit, `separate_multilib_results.py` will keep that naming scheme i.e. postfix with `-non-multilib-report.log`. Therefore, when comparing, we had
`current_logs/gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32d-<applied_hash>-non-multilib-report.log` and
`previous_logs/gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32d-<baseline_hash>-multilib-report.log`. Thus `no-baseline` was found.

Rename the file in current_logs to be `multilib` instead of `non-multilib` to make things consistent