### PR TITLE
fix typo

### DIFF
--- a/.github/workflows/generate-precommit-summary.yaml
+++ b/.github/workflows/generate-precommit-summary.yaml
@@ -188,7 +188,7 @@ jobs:
       - name: Separate multilib logs
         run: |
           python scripts/separate_multilib_results.py -indir current_logs -outdir current_logs
-          mv current_logs/gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.patch_applied_gcchash }}-non-multilib-report.log current_logs/gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.patch_applied_gcchash }}-multilib-report.log
+          mv current_logs/gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32-${{ inputs.patch_applied_gcchash }}-non-multilib-report.log current_logs/gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.patch_applied_gcchash }}-multilib-report.log
         continue-on-error: true
 
       - name: Compare artifacts


### PR DESCRIPTION
previous and current logs both have ilp32 instead of ilp32d. this was causing errors like https://github.com/ewlu/gcc-precommit-ci/actions/runs/9207043918/job/25342839962#step:18:74