### PR TITLE
Ignore long_branch timeout

### DIFF
--- a/test/allowlist/gcc/common.log
+++ b/test/allowlist/gcc/common.log
@@ -1,0 +1,2 @@
+# Timeout
+FAIL: gcc.dg/long_branch.c (test for excess errors)


### PR DESCRIPTION
Jeff mentioned in an email that this timeout was common on his CI too. Interestingly this wasn't an issue until the new runners were added.