### PR TITLE
Bump binutils to 5/28 tip-of-tree

### DIFF
--- a/.github/workflows/generate-precommit-summary.yaml
+++ b/.github/workflows/generate-precommit-summary.yaml
@@ -82,7 +82,7 @@ jobs:
             riscv-gnu-toolchain/newlib
             riscv-gnu-toolchain/pk
             riscv-gnu-toolchain/qemu
-          key: submodules-archive-9
+          key: submodules-archive-10
 
       - name: Initalize gcc
         if: steps.retrieve-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/init-submodules.yaml
+++ b/.github/workflows/init-submodules.yaml
@@ -55,7 +55,7 @@ jobs:
             riscv-gnu-toolchain/glibc
             riscv-gnu-toolchain/newlib
             riscv-gnu-toolchain/qemu
-          key: submodules-archive-9 # Numbered archive to allow for easy transition when bumping submodules
+          key: submodules-archive-10 # Numbered archive to allow for easy transition when bumping submodules
 
       - name: Initalize submodules cache
         id: cache-init
@@ -130,7 +130,7 @@ jobs:
             riscv-gnu-toolchain/glibc
             riscv-gnu-toolchain/newlib
             riscv-gnu-toolchain/qemu
-          key: submodules-archive-9
+          key: submodules-archive-10
 
       - name: Make cache zip
         run: |


### PR DESCRIPTION
This didn't add/resolve any failures for postcommit so it should have no effect on precommit failures either.