### PR TITLE
Fix typo that caused a no-baseline for non-atomic newlib target

### DIFF
--- a/.github/workflows/generate-precommit-summary.yaml
+++ b/.github/workflows/generate-precommit-summary.yaml
@@ -157,7 +157,7 @@ jobs:
       - name: Separate multilib logs
         run: |
           python scripts/separate_multilib_results.py -indir current_logs -outdir current_logs
-          mv current_logs/gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32-${{ inputs.patch_applied_gcchash }}-non-multilib-report.log current_logs/gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.patch_applied_gcchash }}-multilib-report.log
+          mv current_logs/gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32-${{ inputs.patch_applied_gcchash }}-non-multilib-report.log current_logs/gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32-${{ inputs.patch_applied_gcchash }}-multilib-report.log
         continue-on-error: true
 
       - name: Compare artifacts


### PR DESCRIPTION
Reverts ewlu/gcc-precommit-ci#1596
Now that we aren't running duplicates on postcommit:
https://github.com/patrick-rivos/gcc-postcommit-ci/pull/1098
the extraneous resolved-failures won't show up.