### PR TITLE
prevent failures from not finding files

### DIFF
--- a/.github/workflows/downtime-runner.yaml
+++ b/.github/workflows/downtime-runner.yaml
@@ -123,12 +123,18 @@ jobs:
         run: |
           mkdir -p patch_urls
           mkdir -p patchworks_metadata
-          python scripts/create_patches_files.py -file ./patch_numbers_to_run.txt
+          if [ -f ./patch_numbers_to_run.txt ]; then
+            python scripts/create_patches_files.py -file ./patch_numbers_to_run.txt
+          fi
 
       - name: List patch artifacts
         id: list_patches
         run: |
-          export PATCHLIST="$(cat artifact_names.txt)"
+          if [ -f ./artifact_names.txt ]; then
+            export PATCHLIST="$(cat artifact_names.txt)"
+          else
+            export PATCHLIST='[]'
+          fi
           echo "patch_list=$PATCHLIST" >> $GITHUB_OUTPUT
 
       - name: Make artifact zip


### PR DESCRIPTION
The downtime runner reports failures when it fails to find any missed patches to run https://github.com/ewlu/gcc-precommit-ci/actions/runs/9410820797/job/25923111889#step:7:211

It appears to run fine when there are patches that were missed https://github.com/ewlu/gcc-precommit-ci/actions/runs/9433404654