### PR TITLE
Update newlib.rv64.v.log

### DIFF
--- a/test/allowlist/gcc/newlib.rv64.v.log
+++ b/test/allowlist/gcc/newlib.rv64.v.log
@@ -18,3 +18,8 @@ FAIL: gcc.dg/vect/tsvc/vect-tsvc-s351.c
 FAIL: gcc.dg/vect/tsvc/vect-tsvc-s431.c
 FAIL: gcc.dg/vect/tsvc/vect-tsvc-s1281.c
 
+#
+# Related to https://sourceware.org/bugzilla/show_bug.cgi?id=27566
+# https://github.com/ewlu/gcc-precommit-ci/issues/1880
+#
+FAIL: gcc.target/riscv/rvv/autovec/gather-scatter/gather_load_run-11.c


### PR DESCRIPTION
```
/tmp/ccKtigly.o: in function `main':
gather_load_run-11.c:(.text.startup+0x14ba): relocation truncated to fit: R_RISCV_GPREL_I against `.LANCHOR1'
collect2: error: ld returned 1 exit status
compiler exited with status 1
FAIL: gcc.target/riscv/rvv/autovec/gather-scatter/gather_load_run-11.c (test for excess errors)
Excess errors:
gather_load_run-11.c:(.text.startup+0x14ba): relocation truncated to fit: R_RISCV_GPREL_I against `.LANCHOR1'
```