### PR TITLE
Parse new build warnings Integration

### DIFF
--- a/.github/actions/common/download-build-log-artifact/action.yaml
+++ b/.github/actions/common/download-build-log-artifact/action.yaml
@@ -1,0 +1,36 @@
+name: "Download Build Artifacts"
+description: "Downloads artifacts needed for build log comparison"
+inputs:
+  build-artifact-name:
+    required: true
+  github-token:
+    required: true
+  output-dir:
+    required: true
+    description: 'Absolute path to the output directory'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download report from this workflow
+      if: ${{ !cancelled() }}
+      id: same-workflow
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.build-artifact-name }}
+        path: ${{ inputs.output-dir }}
+      continue-on-error: true
+
+    # If an artifact from the same workflow is not found, the conclusion
+    # will be success but the outcome will be failure. 
+    # https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
+    - name: Download report from another workflow
+      if: ${{ !cancelled() && steps.same-workflow.outcome == 'failure' }}
+      id: other-workflow
+      shell: bash
+      run: |
+        pip install pyopenssl --upgrade
+        pip install pygithub requests
+        cd riscv-gnu-toolchain
+        python ./scripts/download_artifact.py -name ${{ inputs.build-artifact-name }} -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+      continue-on-error: true

--- a/.github/actions/common/unzip-all-zips/action.yaml
+++ b/.github/actions/common/unzip-all-zips/action.yaml
@@ -1,0 +1,37 @@
+name: "Unzip all zips"
+description: "Unzip all the zip files located in a given directory"
+inputs:
+  input-dir:
+    description: 'Directory that contains zip files'
+    required: true
+  output-dir:
+    description: 'Output directory that will contain all unzipped files'
+    required: true
+  include-pattern:
+    description: 'Remove all files that does not fit this pattern'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create Output dir
+      id: create-output-dir
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.output-dir }}
+
+    - name: unzip all files
+      shell: bash
+      run: |
+        for zip_file in ${{ inputs.input-dir }}/*.zip; do
+          if [[ -e "$zip_file" ]]; then
+            unzip -o "$zip_file" -d ${{ inputs.output-dir }}
+          fi
+        done
+
+    - name: Filter Include Pattern
+      if: ${{ inputs.include-pattern }} != ''
+      shell: bash
+      run: |
+        find ${{ inputs.output-dir }} -type f ! -name "${{ inputs.include-pattern }}" -exec rm {} \;
+        ls ${{ inputs.output-dir }}

--- a/.github/actions/download-all-build-log-artifacts/action.yaml
+++ b/.github/actions/download-all-build-log-artifacts/action.yaml
@@ -1,0 +1,41 @@
+name: "Download All Build Log Artifacts"
+description: "Downloads all the build log artifacts for a given hash. Only use this action if the given gcchash is not built in the current run"
+inputs:
+  gcchash:
+    required: true
+    description: 'GCC Hash of the artifact'
+  github-token:
+    required: true
+  output-dir:
+    required: true
+    description: 'Absolute Path to the artifact directory'
+
+runs:
+  using: "composite"
+  steps:
+    - name: prereqs
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.output-dir }}
+
+    - name: Download linux rv64gc  non-multilib
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: linux-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
+
+    - name: Download newlib rv64gc non-multilib
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: newlib-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
+
+    #TODO: Support Multilib. Restriction: https://github.com/ewlu/gcc-precommit-ci/pull/1919#discussion_r1686874053
+
+    - name: Print downloaded artifacts
+      shell: bash
+      run: |
+        cd riscv-gnu-toolchain
+        ls ${{ inputs.output-dir }}

--- a/.github/workflows/patchworks.yaml
+++ b/.github/workflows/patchworks.yaml
@@ -164,3 +164,90 @@ jobs:
       tot_hash: ${{ needs.init-submodules.outputs.tot_hash }}
       original_patch_issue_num: ${{ inputs.original_patch_issue_num }}
     secrets: inherit
+
+  build_log_comparison:
+    needs: [patch_matrix, init-submodules]
+    runs-on: ubuntu-20.04
+    environment: production
+    defaults:
+      run:
+        working-directory: riscv-gnu-toolchain
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup env
+        uses: ./.github/actions/common/setup-env
+        with:
+          free_up_space: false
+
+      - name: Build Log Comparison Setup
+        id: build-log-setup
+        run: |
+          mkdir -p previous_build_logs/build
+          echo "previous_build_logs_path=$(readlink -f previous_build_logs)" >> $GITHUB_OUTPUT
+          mkdir -p previous_build_log_zips
+          echo "previous_build_log_zips_path=$(readlink -f previous_build_log_zips)" >> $GITHUB_OUTPUT
+          mkdir -p current_build_logs/build
+          echo "current_build_logs_path=$(readlink -f current_build_logs)" >> $GITHUB_OUTPUT
+          mkdir -p current_build_log_zips
+          echo "current_build_log_zips_path=$(readlink -f current_build_log_zips)" >> $GITHUB_OUTPUT
+          mkdir new_build_warnings
+          echo "new_build_warnings_path=$(readlink -f ./new_build_warnings/new_build_warnings.log)" >> $GITHUB_OUTPUT
+
+      - name: Download current linux rv64gc lp64d non multilib workflow build logs
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ steps.build-log-setup.outputs.current_build_log_zips_path }}
+          pattern: "*-linux-rv64gc-lp64d-non-multilib-build-log"
+          merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Current newlib rv64gc lp64d non multilib Workflow build logs
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ steps.build-log-setup.outputs.current_build_log_zips_path }}
+          pattern: "*-newlib-rv64gc-lp64d-non-multilib-build-log"
+          merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      #TODO: Support Multilib. Restriction: https://github.com/ewlu/gcc-precommit-ci/pull/1919#discussion_r1686874053
+
+      - name: Unzip current build log artifacts
+        uses: ./.github/actions/common/unzip-all-zips
+        with:
+          input-dir: ${{ steps.build-log-setup.outputs.current_build_log_zips_path }}
+          output-dir: ${{ steps.build-log-setup.outputs.current_build_logs_path }}
+          include-pattern: "*-stderr.log"
+
+      - name: Download previous build log artifacts
+        uses: ./.github/actions/download-all-build-log-artifacts
+        with:
+          gcchash: ${{ needs.init-submodules.outputs.baseline_hash }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-dir: ${{ steps.build-log-setup.outputs.previous_build_log_zips_path }}
+
+      - name: Unzip previous build log artifacts
+        id: unzip-previous-build-log-artifacts
+        uses: ./.github/actions/common/unzip-all-zips
+        with:
+          input-dir: ${{ steps.build-log-setup.outputs.previous_build_log_zips_path }}
+          output-dir: ${{ steps.build-log-setup.outputs.previous_build_logs_path }}
+          include-pattern: "*-stderr.log"
+
+      - name: Parse New Build Warnings
+        run: |
+          python ./scripts/parse_new_build_warnings.py --old-dir ${{ steps.build-log-setup.outputs.previous_build_logs_path }}/build --new-dir ${{ steps.build-log-setup.outputs.current_build_logs_path }}/build --output ${{ steps.build-log-setup.outputs.new_build_warnings_path }} --repo pre-commit
+          if [ -f "${{ steps.build-log-setup.outputs.new_build_warnings_path }}" ]; then
+            cat ${{ steps.build-log-setup.outputs.new_build_warnings_path }}
+          else
+            echo "New build logs didn't exist"
+          fi
+        continue-on-error: true
+
+      - name: Upload New Build Warnings
+        uses: actions/upload-artifact@v4
+        with:
+          name: new-build-warnings
+          path: ${{ steps.build-log-setup.outputs.new_build_warnings_path }}
+          retention-days: 90
+        continue-on-error: true


### PR DESCRIPTION
### New Build Comparison Job
This pull request adds a new job to the CI pipeline that runs after the patch_matrix job. The new job aggregates build logs and compares them with the baseline post-commit build log.

### Pre-commit Option for parse_new_build_warnings Script
The pre-commit option for the parse_new_build_warnings script compares all patch series-target combinations from pre-commit builds with the target from post-commit builds. It shows new build warnings at the target granularity level.

### Targets
Currently, only 4 targets that can be directly compared between pre-commit and post-commit are used
- linux-rv32gc_zba_zbb_zbc_zbs-ilp32d-non-multilib
- linux-rv64gc_zba_zbb_zbc_zbs-lp64d-non-multilib
#### Unsupported Targets
After a discussion, the following targets require multilib support due to different targets between post-commit and pre-commit
- linux-rv64gcv-lp64d-multilib
- newlib-rv64gcv-lp64d-multilib