### PR TITLE
Add flaky gfortran/sizeof_6.f90 to allowlist

### DIFF
--- a/test/allowlist/gcc/common.log
+++ b/test/allowlist/gcc/common.log
@@ -1,4 +1,2 @@
 # Timeout
 FAIL: gcc.dg/long_branch.c (test for excess errors)
-# Timeout: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116261
-FAIL: gfortran.dg/sizeof_6.f90   -O1  execution test

--- a/test/allowlist/gcc/common.log
+++ b/test/allowlist/gcc/common.log
@@ -1,2 +1,4 @@
 # Timeout
 FAIL: gcc.dg/long_branch.c (test for excess errors)
+# Timeout: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116261
+FAIL: gfortran.dg/sizeof_6.f90   -O1  execution test

--- a/test/allowlist/gcc/glibc.rv64.zbs.log
+++ b/test/allowlist/gcc/glibc.rv64.zbs.log
@@ -1,0 +1,2 @@
+# Timeout: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116261
+FAIL: gfortran.dg/sizeof_6.f90   -O1  execution test


### PR DESCRIPTION
Seen here:
https://github.com/ewlu/gcc-precommit-ci/issues/2030
and a few other places. Seems to affect every target.