### PR TITLE
Remove double-zip instances

### DIFF
--- a/.github/actions/common/build-target/action.yaml
+++ b/.github/actions/common/build-target/action.yaml
@@ -1,4 +1,4 @@
-name: "Build target" 
+name: "Build target"
 description: "Builds GCC targets"
 inputs:
   multilib_target_string:
@@ -54,7 +54,7 @@ runs:
         run: |
           cd build
           set -o pipefail
-          (make -j 32 ${{ inputs.mode }}) 2> >(tee ${{ inputs.build_log_name }}-stderr.log) > >(tee ${{ inputs.build_log_name }}-stdout.log) | tee ${{ inputs.build_log_name }}.log 
+          (make -j 32 ${{ inputs.mode }}) 2> >(tee ${{ inputs.build_log_name }}-stderr.log) > >(tee ${{ inputs.build_log_name }}-stdout.log) | tee ${{ inputs.build_log_name }}.log
           set +o pipefail
 
       - name: Upload build log
@@ -68,18 +68,12 @@ runs:
             riscv-gnu-toolchain/build/${{ inputs.build_log_name }}-stderr.log
           retention-days: 90
 
-      - name: Zip binaries
-        shell: bash
-        working-directory: riscv-gnu-toolchain
-        run: |
-          zip -r gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}.zip build/bin
-
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
           name: gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}
           path: |
-            riscv-gnu-toolchain/gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}.zip
+            riscv-gnu-toolchain/build/bin
           retention-days: 5
 
       # Running testsuite (stamps/check-gcc-*) only uses stage2 & assorted folders

--- a/.github/actions/common/run-testsuite/action.yaml
+++ b/.github/actions/common/run-testsuite/action.yaml
@@ -24,7 +24,7 @@ runs:
           cd build
           make -j 32 report-${{ inputs.mode }} || true
 
-      - name: Build debug log zip
+      - name: Build debug log
         shell: bash
         working-directory: riscv-gnu-toolchain
         run: |
@@ -33,7 +33,6 @@ runs:
           else
             cat `find build/build-gcc-linux-stage2/gcc/testsuite/ -name g*.log` > gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-debug-output.log
           fi
-          zip -r gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-debug-output.zip gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-debug-output.log
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v4
@@ -43,7 +42,7 @@ runs:
             riscv-gnu-toolchain/gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-debug-output.log
           retention-days: 90
 
-      - name: Build sum files zip
+      - name: Build sum files
         shell: bash
         working-directory: riscv-gnu-toolchain
         run: |
@@ -53,14 +52,13 @@ runs:
           else
             for file in `find build/build-gcc-linux-stage2/gcc/testsuite/ -name g*.sum`; do cp $file sum_files; done
           fi
-          zip -r gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-sum-files.zip sum_files
 
       - name: Upload sum file artifacts
         uses: actions/upload-artifact@v4
         with:
           name: gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-sum-files
           path: |
-            riscv-gnu-toolchain/gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-sum-files.zip
+            riscv-gnu-toolchain/sum_files
           retention-days: 90
 
       - name: Save results

--- a/.github/actions/extract-apply-patches-trunk-or-baseline/action.yaml
+++ b/.github/actions/extract-apply-patches-trunk-or-baseline/action.yaml
@@ -21,13 +21,7 @@ runs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.patch_name }}-downloaded-patches
-          path: ./riscv-gnu-toolchain
-
-      - name: Extract patches
-        shell: bash
-        working-directory: riscv-gnu-toolchain
-        run: |
-          unzip ${{ inputs.patch_name }}-downloaded-patches.zip
+          path: ./riscv-gnu-toolchain/patches
 
       - name: Checkout gcc hash
         shell: bash

--- a/.github/workflows/downtime-runner.yaml
+++ b/.github/workflows/downtime-runner.yaml
@@ -53,14 +53,13 @@ jobs:
             echo "start_date=$START_DATE" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build success artifact 
+      - name: Build success artifact
         if: ${{ steps.continue.outputs.start_date == '' }}
         run: |
           TZ=UTC date -d "$(date -d 'yesterday' '+%Y-%m-%d')" "+%Y-%m-%dT%H:%M:%S" > yesterday_date.txt
           YESTERDAY=$(cat yesterday_date.txt)
           # Get yestderay noon
           TZ=UTC date -d "@$((($(TZ=UTC date -d $YESTERDAY +%s) + 43200)))" '+%Y-%m-%dT%H:%M:%S' > end_date.txt
-          zip end_date.zip end_date.txt
 
       - name: Upload success artifact
         if: ${{ steps.continue.outputs.start_date == '' }}
@@ -68,7 +67,7 @@ jobs:
         with:
           name: downtime_runner_success
           path: |
-            riscv-gnu-toolchain/end_date.zip
+            riscv-gnu-toolchain/end_date.txt
           retention-days: 90
 
     outputs:
@@ -137,27 +136,22 @@ jobs:
           fi
           echo "patch_list=$PATCHLIST" >> $GITHUB_OUTPUT
 
-      - name: Make artifact zip
-        run: |
-          zip -r patch_files.zip patch_urls
-          zip -r patchworks_metadata_files.zip patchworks_metadata
-
-      - name: Upload patch urls zip
+      - name: Upload patch urls
         if: ${{ steps.list_patches.outputs.patch_list != '[]' }}
         uses: actions/upload-artifact@v4
         with:
           name: patch_urls
           path: |
-            riscv-gnu-toolchain/patch_files.zip
+            riscv-gnu-toolchain/patch_urls
           retention-days: 90
 
-      - name: Upload patchworks metadata zip
+      - name: Upload patchworks metadata
         if: ${{ steps.list_patches.outputs.patch_list != '[]' }}
         uses: actions/upload-artifact@v4
         with:
           name: patchworks_metadata_files
           path: |
-            riscv-gnu-toolchain/patchworks_metadata_files.zip
+            riscv-gnu-toolchain/patchworks_metadata
           retention-days: 90
 
     outputs:

--- a/.github/workflows/generate-precommit-summary.yaml
+++ b/.github/workflows/generate-precommit-summary.yaml
@@ -257,11 +257,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.patch_name }}-downloaded-patches
-          path: ./riscv-gnu-toolchain
-
-      - name: Extract patches
-        run: |
-          unzip ${{ inputs.patch_name }}-downloaded-patches.zip
+          path: ./riscv-gnu-toolchain/patches
 
       - name: Print API usage info
         run: |

--- a/.github/workflows/generate-precommit-summary.yaml
+++ b/.github/workflows/generate-precommit-summary.yaml
@@ -177,18 +177,12 @@ jobs:
           rm current_logs/failed_testsuite.txt
         continue-on-error: true
 
-      - name: Make artifact zips
-        run: |
-          zip -r summaries.zip summaries
-          zip -r current_logs.zip current_logs
-          zip -r previous_logs.zip previous_logs
-
       - name: Upload compare summaries
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.patch_applied_gcchash }}-summaries
           path: |
-            riscv-gnu-toolchain/summaries.zip
+            riscv-gnu-toolchain/summaries
           retention-days: 90
 
       - name: Upload current log failures
@@ -196,7 +190,7 @@ jobs:
         with:
           name: ${{ inputs.patch_applied_gcchash }}-current-logs
           path: |
-            riscv-gnu-toolchain/current_logs.zip
+            riscv-gnu-toolchain/current_logs
           retention-days: 90
 
       - name: Upload baseline results
@@ -204,7 +198,7 @@ jobs:
         with:
           name: ${{ inputs.patch_applied_gcchash }}-previous-logs
           path: |
-            riscv-gnu-toolchain/previous_logs.zip
+            riscv-gnu-toolchain/previous_logs
           retention-days: 90
 
     outputs:
@@ -298,11 +292,11 @@ jobs:
 
       - name: Trim comment length # reduce the number of lines in final comment so github always creates comment
         run: |
-          # Max comment length is 65536. Allocate 1536 for extra statements 
+          # Max comment length is 65536. Allocate 1536 for extra statements
           head -c 64000 comment.md > trimmed_comment.md
           FILE_SIZE=$(stat -c%s "comment.md")
-          if [ $FILE_SIZE -gt 64000 ]; then 
-            printf "\n\`\`\`\nComment text has been trimmed. Please check logs for the untrimmed comment." >> trimmed_comment.md; 
+          if [ $FILE_SIZE -gt 64000 ]; then
+            printf "\n\`\`\`\nComment text has been trimmed. Please check logs for the untrimmed comment." >> trimmed_comment.md;
             # Max gist bytes are 1048576. Allocate 576 for extra statements
             ONE_MB_IN_BYTES=1048000
             if [ $FILE_SIZE -gt $ONE_MB_IN_BYTES ]; then

--- a/.github/workflows/generate-precommit-summary.yaml
+++ b/.github/workflows/generate-precommit-summary.yaml
@@ -226,19 +226,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.patch_applied_gcchash }}-summaries
-          path: ./riscv-gnu-toolchain
+          path: ./riscv-gnu-toolchain/summaries
 
       - name: Download current logs artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.patch_applied_gcchash }}-current-logs
-          path: ./riscv-gnu-toolchain
+          path: ./riscv-gnu-toolchain/current_logs
 
       - name: Download previous logs artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.patch_applied_gcchash }}-previous-logs
-          path: ./riscv-gnu-toolchain
+          path: ./riscv-gnu-toolchain/previous_logs
 
       - name: Download patches artifact
         if: ${{ needs.compare-artifacts.outputs.workflow_dispatch == 'true' }}
@@ -268,9 +268,6 @@ jobs:
 
       - name: Aggregate information
         run: |
-          unzip summaries.zip
-          unzip current_logs.zip
-          unzip previous_logs.zip
           python ./scripts/aggregate.py \
             -chash ${{ inputs.patch_applied_gcchash }} \
             -patch ${{ inputs.patch_name }} \

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,11 +52,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.patch_name }}-downloaded-patches
-          path: ./riscv-gnu-toolchain
-
-      - name: Extract patches
-        run: |
-          unzip ${{ inputs.patch_name }}-downloaded-patches.zip
+          path: ./riscv-gnu-toolchain/patches
 
       - name: Install prereqs
         run: |

--- a/.github/workflows/patchworks.yaml
+++ b/.github/workflows/patchworks.yaml
@@ -115,27 +115,22 @@ jobs:
           export PATCHLIST="$(cat artifact_names.txt)"
           echo "patch_list=$PATCHLIST" >> $GITHUB_OUTPUT
 
-      - name: Make artifact zip
-        run: |
-          zip -r patch_files.zip patch_urls
-          zip -r patchworks_metadata_files.zip patchworks_metadata
-
-      - name: Upload patch urls zip
+      - name: Upload patch urls
         if: ${{ steps.list_patches.outputs.patch_list != '[]' }}
         uses: actions/upload-artifact@v4
         with:
           name: patch_urls
           path: |
-            riscv-gnu-toolchain/patch_files.zip
+            riscv-gnu-toolchain/patch_urls
           retention-days: 90
 
-      - name: Upload patchworks metadata zip
+      - name: Upload patchworks metadata
         if: ${{ steps.list_patches.outputs.patch_list != '[]' }}
         uses: actions/upload-artifact@v4
         with:
           name: patchworks_metadata_files
           path: |
-            riscv-gnu-toolchain/patchworks_metadata_files.zip
+            riscv-gnu-toolchain/patchworks_metadata
           retention-days: 90
 
     outputs:

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -76,11 +76,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.patch_name }}-downloaded-patches
-          path: ./riscv-gnu-toolchain
-
-      - name: Extract patches
-        run: |
-          unzip ${{ inputs.patch_name }}-downloaded-patches.zip
+          path: ./riscv-gnu-toolchain/patches
 
       - name: Build initial issue
         run: |
@@ -219,11 +215,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.patch_name }}-downloaded-patches
-          path: ./riscv-gnu-toolchain
-
-      - name: Extract patches
-        run: |
-          unzip ${{ inputs.patch_name }}-downloaded-patches.zip
+          path: ./riscv-gnu-toolchain/patches
 
       - name: Checkout gcc hash
         run: |
@@ -400,11 +392,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.patch_name }}-downloaded-patches
-          path: ./riscv-gnu-toolchain
-
-      - name: Extract patches
-        run: |
-          unzip ${{ inputs.patch_name }}-downloaded-patches.zip
+          path: ./riscv-gnu-toolchain/patches
 
       - name: Create build pending comment
         run: |

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -34,18 +34,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: patch_urls
-          path: ./riscv-gnu-toolchain
+          path: ./riscv-gnu-toolchain/patch_urls
 
       - name: Download patchworks urls artifact
         uses: actions/download-artifact@v4
         with:
           name: patchworks_metadata_files
-          path: ./riscv-gnu-toolchain
-
-      - name: Extract downloaded files
-        run: |
-          unzip patch_files.zip
-          unzip patchworks_metadata_files.zip
+          path: ./riscv-gnu-toolchain/patchworks_metadata
 
       - name: Download patches from urls
         run: |

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -53,16 +53,12 @@ jobs:
           scripts/download_patches.sh -p ${{ inputs.patch_name }}
           mv patchworks_metadata/${{ inputs.patch_name }} patches/
 
-      - name: Zip patches
-        run: |
-          zip -r ${{ inputs.patch_name }}-downloaded-patches.zip patches
-
       - name: Upload patches artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.patch_name }}-downloaded-patches
           path: |
-            riscv-gnu-toolchain/${{ inputs.patch_name }}-downloaded-patches.zip
+            riscv-gnu-toolchain/patches
           retention-days: 90
 
   create-issue:


### PR DESCRIPTION
This'll probably break but it's a step in the right direction. We can handle postcommit later.