### PR TITLE
Build Log Concurrency Fix

### DIFF
--- a/.github/actions/common/build-target/action.yaml
+++ b/.github/actions/common/build-target/action.yaml
@@ -54,7 +54,7 @@ runs:
         run: |
           cd build
           set -o pipefail
-          (make -j 32 ${{ inputs.mode }}) 2> >(tee ${{ inputs.build_log_name }}-stderr.log) > >(tee ${{ inputs.build_log_name }}-stdout.log) | tee ${{ inputs.build_log_name }}.log
+          (make -j 32  --output-sync=target ${{ inputs.mode }}) 2> >(tee ${{ inputs.build_log_name }}-stderr.log) > >(tee ${{ inputs.build_log_name }}-stdout.log) | tee ${{ inputs.build_log_name }}.log
           set +o pipefail
 
       - name: Upload build log


### PR DESCRIPTION
Apply the same changes as https://github.com/patrick-rivos/gcc-postcommit-ci/pull/1864.