### PR TITLE
add empty dir check

### DIFF
--- a/.github/workflows/patchworks.yaml
+++ b/.github/workflows/patchworks.yaml
@@ -126,14 +126,17 @@ jobs:
             python scripts/create_patches_files.py -backup $(cat prior_run_time_minus_15_min_rounded.txt) -start $(cat prior_run_time_rounded.txt) -end $(cat current_time_rounded.txt) -all-patches
             echo "all found patches"
             ls patch_urls
-            # perform the difference
-            for file in riscv_patch_urls/*; do
-              base=$(basename $file)
-              echo "removing $base from all found patches"
-              rm -rf patch_urls/$base patchworks_metadata/$base
-              cat artifact_names.txt | sed "s/\s*'$base'\s*//g" | sed "s/,,/,/g" > temp.txt
-              mv temp.txt artifact_names.txt
-            done
+            # if there are riscv patches in this batch, remove them. otherwise leave as is
+            if [ "$(ls riscv_patch_urls)" ]; then
+              # perform the difference
+              for file in riscv_patch_urls/*; do
+                base=$(basename $file)
+                echo "removing $base from all found patches"
+                rm -rf patch_urls/$base patchworks_metadata/$base
+                cat artifact_names.txt | sed "s/\s*'$base'\s*//g" | sed "s/,,/,/g" | sed "s/,]/]/g" | sed "s/[,/[/g"> temp.txt
+                mv temp.txt artifact_names.txt
+              done
+            fi
           fi
 
       - name: List patch artifacts


### PR DESCRIPTION
if there were no riscv patches but non-riscv non riscv patches were found, the empty directory would mess with the file removal process. essentially, the 
```
for file in riscv_patch_urls/*; do
  base=$(basename $file)
```
would result in `base == *`. This, in conjunction with the `sed` statements would strip the list of quotations. Therefore, when parsing the list of patch names with `fromJSON()`, a parsing error occurs since the list is no longer a json string list.

Add additional check to only perform the removal actions if riscv patches were found