### PR TITLE
fix sed command

### DIFF
--- a/.github/workflows/patchworks.yaml
+++ b/.github/workflows/patchworks.yaml
@@ -133,7 +133,7 @@ jobs:
                 base=$(basename $file)
                 echo "removing $base from all found patches"
                 rm -rf patch_urls/$base patchworks_metadata/$base
-                cat artifact_names.txt | sed "s/\s*'$base'\s*//g" | sed "s/,,/,/g" | sed "s/,]/]/g" | sed "s/[,/[/g"> temp.txt
+                cat artifact_names.txt | sed "s/\s*'$base'\s*//g" | sed "s/,,/,/g" | sed "s/,\]/\]/g" | sed "s/\[,/\[/g"> temp.txt
                 mv temp.txt artifact_names.txt
               done
             fi


### PR DESCRIPTION
https://github.com/ewlu/gcc-precommit-ci/actions/runs/12399167844/job/34613508992#step:8:239

`[` was being treated as a special character instead of being the target of the pattern match. Since `,]` was being accepted as a valid pattern match, I assumed `[,` would be as well but forgot `[...]` is a valid regex construct. As a result, `sed` would error when the non-riscv patch list was empty.

```
(venv) ewlu@ewlu:/scratch/ewlu/ci/riscv-gnu-toolchain$ cat test.txt
['42125-vect_Do_not_use_partial_vectors_when_emulating_vectors_PR116351-1']
(venv) ewlu@ewlu:/scratch/ewlu/ci/riscv-gnu-toolchain$ echo $base
42125-vect_Do_not_use_partial_vectors_when_emulating_vectors_PR116351-1

# previous sed command
(venv) ewlu@ewlu:/scratch/ewlu/ci/riscv-gnu-toolchain$ cat test.txt | sed "s/\s*'$base'\s*//g" | sed "s/,,/,/g" | sed "s/,]/]/g" | sed "s/[,/[/g"
sed: -e expression #1, char 8: unterminated `s' command
# updated sed command
(venv) ewlu@ewlu:/scratch/ewlu/ci/riscv-gnu-toolchain$ cat test.txt | sed "s/\s*'$base'\s*//g" | sed "s/,,/,/g" | sed "s/,]/]/g" | sed "s/\[,/\[/g"
[]
```