### PR TITLE
fix download check

### DIFF
--- a/.github/workflows/downtime-runner.yaml
+++ b/.github/workflows/downtime-runner.yaml
@@ -45,11 +45,7 @@ jobs:
       - name: Check if artifact was found
         id: continue
         run: |
-          if ( test -f result/downtime_runner_success ); then
-            unzip result/downtime_runner_success
-            ls
-            unzip end_date.zip
-            ls
+          if ( test -f result/end_date.txt ); then
             START_DATE=$(cat end_date.txt)
             echo "start_date=$START_DATE" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
One of kevin's changes was that the `download_artifact.py` script now immediately extracts the values into the output directory. However, we didn't update the change to the downtime runner so the logs show
```
Run mkdir result
  mkdir result
  mkdir temp
  python ./scripts/download_artifact.py -name "downtime_runner_success" -repo ewlu/gcc-precommit-ci -token *** -outdir result || true
  ls result
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.11.13/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.13/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.13/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.13/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.13/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.13/x64/lib
##[debug]Overwrite 'working-directory' base on job defaults.
##[debug]/usr/bin/bash -e /home/runner/work/_temp/820b727b-228b-[45](https://github.com/ewlu/gcc-precommit-ci/actions/runs/17198138561/job/48783568251#step:7:45)90-898f-61215c96dbfb.sh
download for downtime_runner_success: 200
end_date.txt <-- ls result output
```
causing this check `if ( test -f result/downtime_runner_success ); then` to fail. This resulted in the downtime runner never actually doing anything 